### PR TITLE
Nodemon script 2

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,16 +6,17 @@
   "scripts": {
     "start": "node app",
     "build": "webpack && node app @apostrophecms/asset:build",
-    "dev": "nodemon --delay 1000ms -x \"npm run build && ENV=dev nodemon app.js\""
+    "dev-serve": "webpack serve & nodemon app.js",
+    "dev": "node app @apostrophecms/asset:build && npm run dev-serve"
   },
   "nodemonConfig": {
+    "delay": 1000,
     "verbose": true,
     "watch": [
       "./app.js",
       "./modules/**/*",
       "./lib/**/*.js",
-      "./views/**/*.html",
-      "./src/**/*"
+      "./views/**/*.html"
     ],
     "ignoreRoot": [
       ".git"


### PR DESCRIPTION
The original script had the right idea, the `&` was not a bug because running webpack serve in the background is necessary in order for the apostrophe app itself to run simultaneously. However there was probably an order of operations issue. I tried grouping with `( )` but that didn't play very well in an npm script, so instead I used a separate npm script to achieve the grouping.

What's actually going on here now is:

* apostrophe core frontend assets are only built once, there's no auto rebuild on that because rebuilding them is slow and the developer is presumably listening to our guidance and using the webpack build (putting their code in `src`) for their own frontend assets. If not they can tweak package.json themselves.
* "webpack serve" stays running and handles hot module reloading for `src`. So `nodemon` does not watch `src` as that would lose the benefit.
* "nodemon" is in the foreground, running the actual apostrophe app and rebuilding when server-side project level files change.
* This isn't intended for rapid debugging of Apostrophe core itself, for that the build in a3-demo is more appropriate. This build is appropriate for project level development.