### PR TITLE
Fix layout styles to target "apos refreshable" elements correctly

### DIFF
--- a/modules/asset/ui/src/scss/_layout.scss
+++ b/modules/asset/ui/src/scss/_layout.scss
@@ -1,23 +1,21 @@
 // Use flex to keep the footer at the bottom.
 body,
-.apos-refreshable,
+[data-apos-refreshable],
 .bp-wrapper {
   display: flex;
   flex-direction: column;
 }
 
-body {
-  display: flex;
-  flex-direction: column;
-  min-height: 100vh;
-  // Nice system fonts.
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
-}
-
-.apos-refreshable,
+[data-apos-refreshable],
 .bp-wrapper,
 main {
   flex-grow: 1;
+}
+
+body {
+  min-height: 100vh;
+  // Nice system fonts.
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol";
 }
 
 .bp-header,


### PR DESCRIPTION
Fixed the styles to keep the footer at the bottom on mostly-empty pages, as it seems it was intended:
![image](https://user-images.githubusercontent.com/3198597/138855395-29565c96-f1ca-4ede-b5a5-ceeeb1966e16.png)

Element selectors in _layout.scss were targeting `.apos-refreshable` when they should be targeting `[data-apos-refreshable]`.